### PR TITLE
Ensure PWA works on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,13 @@
     <!-- PWA Meta Tags -->
     <meta name="description" content="AI-powered at-home activity prompts for couples">
     <meta name="theme-color" content="#3b82f6">
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="manifest.json">
     
     <!-- Apple PWA Meta Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="CoupleCrafts">
-    <link rel="apple-touch-icon" href="/images/icon-192.png">
+    <link rel="apple-touch-icon" href="images/icon-192.png">
     
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -35,7 +35,7 @@
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
     
     <!-- Custom Styles -->
-    <link rel="stylesheet" href="/css/styles.css">
+    <link rel="stylesheet" href="css/styles.css">
 </head>
 <body class="bg-gray-900 text-white min-h-screen">
     <div id="app" x-data="app()" class="flex flex-col min-h-screen">
@@ -293,16 +293,16 @@
     <div id="scrapbook-template" class="hidden"></div>
 
     <!-- Scripts -->
-    <script src="/js/db.js"></script>
-    <script src="/js/ai.js"></script>
+    <script src="js/db.js"></script>
+    <script src="js/ai.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
-    <script src="/js/app.js"></script>
+    <script src="js/app.js"></script>
     
     <script>
         // Register service worker
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('/sw.js')
+                navigator.serviceWorker.register('sw.js')
                     .then(registration => console.log('SW registered'))
                     .catch(error => console.log('SW registration failed'));
             });

--- a/js/app.js
+++ b/js/app.js
@@ -145,7 +145,7 @@ function app() {
         // Activity management
         async loadFallbackActivities() {
             try {
-                const response = await fetch('/data/fallback-activities.json');
+                const response = await fetch('data/fallback-activities.json');
                 const data = await response.json();
                 this.fallbackActivities = data.activities;
                 console.log(`Loaded ${this.fallbackActivities.length} fallback activities`);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "CoupleCrafts",
   "short_name": "CoupleCrafts",
   "description": "AI-powered at-home activity prompts for couples",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#1f2937",
   "theme_color": "#3b82f6",

--- a/sw.js
+++ b/sw.js
@@ -1,12 +1,12 @@
 const CACHE_NAME = 'couplecrafts-v1';
 const urlsToCache = [
-  '/',
-  '/index.html',
-  '/css/styles.css',
-  '/js/app.js',
-  '/js/db.js',
-  '/js/ai.js',
-  '/data/fallback-activities.json',
+  './',
+  'index.html',
+  'css/styles.css',
+  'js/app.js',
+  'js/db.js',
+  'js/ai.js',
+  'data/fallback-activities.json',
   'https://cdn.tailwindcss.com/3.3.0',
   'https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js'
 ];
@@ -36,12 +36,12 @@ self.addEventListener('fetch', event => {
         }
         return fetch(event.request);
       })
-      .catch(() => {
-        // If both cache and network fail, return offline page for navigation requests
-        if (event.request.destination === 'document') {
-          return caches.match('/index.html');
-        }
-      })
+        .catch(() => {
+          // If both cache and network fail, return offline page for navigation requests
+          if (event.request.destination === 'document') {
+            return caches.match('index.html');
+          }
+        })
   );
 });
 


### PR DESCRIPTION
## Summary
- use relative asset paths in HTML for manifest, icons, CSS and scripts
- set manifest start_url to `./`
- scope service worker and fetches to relative paths for GitHub Pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aba084be748327a8f4d9deb9156972