### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ All data (activities, history, photos, settings) is stored locally via IndexedDB
 - Uses Tailwind via CDN and Alpine.js.
 - Service worker (`sw.js`) enables offline use after first load.
 
+## Deployment
+- A `.nojekyll` file is included so GitHub Pages serves files without Jekyll processing.
+- The GitHub Actions workflow at `.github/workflows/deploy.yml` publishes the site whenever changes are pushed to `main`.
+  - Enable GitHub Pages in the repository settings and select "GitHub Actions" as the source.
+
 ## Troubleshooting
 - Blank activities list: ensure `data/fallback-activities.json` is served (requires local server due to fetch).
 - AI failures: use "Save & Test" in Settings to verify keys; watch for 401/403 (bad key) or 429 (rate limit).


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy main branch to Pages
- document GitHub Pages setup and include `.nojekyll`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abbbb3af4c8327abf7519705eef844