### PR TITLE
Use Gemini 1.5 Flash and drop Hugging Face option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 AI-powered at-home activity prompts for couples. Works fully client-side as a simple PWA.
 
 ## Features
-- AI-generated activities (Google AI Studio Gemini or Hugging Face Inference)
+- AI-generated activities (Google AI Studio Gemini 1.5 Flash)
 - Curated fallback activities
 - Favorites and ratings
 - Activity history with notes and photo attachments
@@ -22,15 +22,12 @@ AI-powered at-home activity prompts for couples. Works fully client-side as a si
 
 2. In the app, open Settings (gear icon):
    - Toggle "AI Generation" ON to enable API use.
-   - Pick a provider: "Google AI Studio (Gemini)" or "Hugging Face (Mistral-7B)".
-   - Paste your API key.
+   - Paste your Google AI Studio API key.
    - Click "Save & Test" to validate the connection.
 
 ## API Keys
 - Google AI Studio (Gemini): create a key at https://aistudio.google.com/app/apikey
-  - Model endpoint used: `gemini-pro:generateContent` (v1beta).
-- Hugging Face Inference: create a key at https://huggingface.co/settings/tokens
-  - Model used: `mistralai/Mistral-7B-Instruct-v0.1`.
+  - Model endpoint used: `gemini-1.5-flash-latest:generateContent` (v1beta).
 
 Notes:
 - Keys are stored in IndexedDB locally in your browser.

--- a/index.html
+++ b/index.html
@@ -71,10 +71,9 @@
                     <div x-show="aiEnabled" class="space-y-2">
                         <label class="text-sm">AI Provider</label>
                         <select x-model="aiProvider" class="w-full p-2 rounded bg-gray-700 text-white">
-                            <option value="gemini">Google AI Studio (Gemini)</option>
-                            <option value="huggingface">Hugging Face (Mistral-7B)</option>
+                            <option value="gemini">Google AI Studio (Gemini 1.5 Flash)</option>
                         </select>
-                        <input x-model="apiKey" type="password" placeholder="API Key" 
+                        <input x-model="apiKey" type="password" placeholder="API Key"
                                class="w-full p-2 rounded bg-gray-700 text-white placeholder-gray-400">
                         <button @click="saveSettingsAndTest()" class="bg-primary hover:bg-blue-600 text-white px-4 py-2 rounded text-sm">Save & Test</button>
                     </div>

--- a/js/ai.js
+++ b/js/ai.js
@@ -3,13 +3,8 @@ class AIService {
     constructor() {
         this.providers = {
             gemini: {
-                name: 'Google AI Studio (Gemini)',
-                endpoint: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent',
-                requiresKey: true
-            },
-            huggingface: {
-                name: 'Hugging Face (Mistral-7B)',
-                endpoint: 'https://api-inference.huggingface.co/models/mistralai/Mistral-7B-Instruct-v0.1',
+                name: 'Google AI Studio (Gemini 1.5 Flash)',
+                endpoint: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent',
                 requiresKey: true
             }
         };
@@ -23,9 +18,6 @@ class AIService {
             switch (provider) {
                 case 'gemini':
                     response = await this.callGemini(apiKey, prompt);
-                    break;
-                case 'huggingface':
-                    response = await this.callHuggingFace(apiKey, prompt);
                     break;
                 default:
                     throw new Error('Unknown AI provider');
@@ -114,42 +106,6 @@ Make it creative, romantic, and themed around ${selectedTheme}. Ensure all instr
         }
 
         return data.candidates[0].content.parts[0].text;
-    }
-
-    async callHuggingFace(apiKey, prompt) {
-        const response = await fetch(this.providers.huggingface.endpoint, {
-            method: 'POST',
-            headers: {
-                'Authorization': `Bearer ${apiKey}`,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                inputs: prompt,
-                parameters: {
-                    max_new_tokens: 1024,
-                    temperature: 0.7,
-                    top_p: 0.95,
-                    do_sample: true,
-                    return_full_text: false
-                }
-            })
-        });
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            let friendly = `Hugging Face API error: ${response.status}`;
-            if (response.status === 401 || response.status === 403) friendly += ' (unauthorized)';
-            if (response.status === 429) friendly += ' (rate limit)';
-            throw new Error(`${friendly} - ${errorText}`);
-        }
-
-        const data = await response.json();
-        
-    if (!data || !data[0] || !data[0].generated_text) {
-            throw new Error('Invalid response from Hugging Face API');
-        }
-
-        return data[0].generated_text;
     }
 
     parseActivityResponse(response) {
@@ -249,9 +205,6 @@ Make it creative, romantic, and themed around ${selectedTheme}. Ensure all instr
             switch (provider) {
                 case 'gemini':
                     await this.callGemini(apiKey, testPrompt);
-                    break;
-                case 'huggingface':
-                    await this.callHuggingFace(apiKey, testPrompt);
                     break;
                 default:
                     throw new Error('Unknown provider');

--- a/js/app.js
+++ b/js/app.js
@@ -94,6 +94,10 @@ function appStore() {
             try {
                 this.aiEnabled = await window.coupleCraftsDB.getSetting('aiEnabled', false);
                 this.aiProvider = await window.coupleCraftsDB.getSetting('aiProvider', 'gemini');
+                if (!window.aiService.getProviderInfo(this.aiProvider)) {
+                    this.aiProvider = 'gemini';
+                    await window.coupleCraftsDB.saveSetting('aiProvider', this.aiProvider);
+                }
                 this.apiKey = await window.coupleCraftsDB.getSetting('apiKey', '');
             } catch (error) {
                 console.error('Failed to load settings:', error);


### PR DESCRIPTION
## Summary
- remove Hugging Face provider and related code
- update Google AI integration to Gemini 1.5 Flash endpoint
- clean up settings loader to default to Gemini when unknown provider saved

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0b102d44832785e15c1cadfe4784